### PR TITLE
always send messages async so mandrill doesn't timeout

### DIFF
--- a/lib/mandrill_dm/delivery_method.rb
+++ b/lib/mandrill_dm/delivery_method.rb
@@ -9,7 +9,7 @@ module MandrillDm
     def deliver!(mail)
       mandrill_api = Mandrill::API.new(MandrillDm.configuration.api_key)
       message = Message.new(mail)
-      @response = mandrill_api.messages.send(message.to_json)
+      @response = mandrill_api.messages.send(message.to_json, true)
     end
   end
 end


### PR DESCRIPTION
@ropiku There's probably a better way to do this, but we get several failures per day because mandrill times out trying to send, and we return a 50x to the user.
